### PR TITLE
Add concept doc for Chainlit ADK WYSIWYG editor

### DIFF
--- a/docs/agent-wysiwyg-editor.md
+++ b/docs/agent-wysiwyg-editor.md
@@ -1,0 +1,119 @@
+# Chainlit + ADK Agent WYSIWYG Editor Concept
+
+This document outlines a proposed approach for wrapping the ADK Web backend and a Chainlit-based frontend into a unified **"build, preview, and deploy"** experience. The goal is to enable non-technical operators to configure agents using a graphical editor while still following engineering best practices such as DRY configuration, centralized secrets management, and repeatable deployment.
+
+## High-Level Architecture
+
+| Layer | Responsibilities | Notes |
+| --- | --- | --- |
+| **Admin/WYSIWYG Editor (Chainlit)** | Collect agent metadata, prompt snippets, tool definitions, testing scenarios, and deployment targets. | Build on Chainlit components; persist state via backend API. |
+| **ADK Web Backend** | Validates agent definitions, stores reusable components, runs dry-run evaluations, and orchestrates deployments. | Implement REST/GraphQL endpoints secured by OAuth2 or IAM-backed service accounts. |
+| **Agent Runtime (Agent Engine)** | Executes deployed agents with versioned configs, centralized secrets, and monitoring hooks. | Recommend Cloud Run or GKE for autoscaling and IAM integration. |
+| **Shared Services** | Configuration registry, secret manager, observability stack, artifact storage, CI/CD pipeline. | Prefer managed GCP services: Secret Manager, Artifact Registry, Cloud Build, Cloud Logging/Monitoring. |
+
+## Editor UX Building Blocks
+
+### 1. Agent Definition Canvas
+- Modular panels for **System Prompt**, **Behaviors/Policies**, **Tools**, and **Deployment Targets**.
+- Each panel saves drafts to a versioned configuration document (e.g., Firestore, PostgreSQL, or Cloud SQL) via ADK Web APIs.
+- Provide inline linting using shared validation rules from the backend to keep behavior consistent (DRY).
+
+### 2. Reusable Snippets Library
+- Enable product teams to curate prompt snippets and tool templates stored in a central registry (`/shared/prompts/*.md`).
+- Editor references these snippets by ID; runtime resolves latest versions, ensuring updates propagate automatically.
+- Guardrails can be expressed in Markdown front matter (YAML) to declare required environment variables, IAM roles, or quotas.
+
+### 3. Scenario Testing Harness
+- Allow authors to define test cases in Markdown:
+  ```markdown
+  ---
+  id: onboarding_flow
+  objective: Validate welcome script alignment
+  input:
+    user_message: "I forgot my password"
+  expected_outcomes:
+    - contains: "password reset"
+    - metric: latency_ms < 1500
+  ---
+  ```
+- Editor triggers backend dry-run execution using recorded fixtures. Results surface inline with metrics and logs.
+
+### 4. Deployment Panel
+- Surface target environments (e.g., `dev`, `staging`, `prod`) sourced from a centrally managed configuration service.
+- Require selection of a runtime version and config snapshot before enabling **Deploy to Agent Engine**.
+- Deployments invoke Cloud Build to package the agent bundle, push to Artifact Registry, and roll out to Cloud Run / GKE with blue-green or canary strategies.
+
+## Configuration & Secrets Management
+
+- Never embed secrets or environment-specific constants inside Markdown. Instead, reference environment variables (e.g., `${LLM_API_KEY}`) that are resolved server-side.
+- Store secrets in **GCP Secret Manager** with automated rotation; expose read-only versions to runtimes through IAM.
+- Keep shared configuration (e.g., tool endpoints, dataset IDs) in a dedicated `config` service or GitOps repo, referenced by immutable IDs from the editor.
+
+## Recommended GCP Services
+
+| Requirement | GCP Service | Rationale |
+| --- | --- | --- |
+| Centralized secrets | Secret Manager | Versioned secrets with IAM-based access. |
+| Config storage | Firestore or Cloud SQL | Choose based on transaction/relational needs. |
+| Artifact packaging | Cloud Build + Artifact Registry | Automated builds and image storage. |
+| Runtime hosting | Cloud Run (serverless) or GKE (custom scaling) | Supports HTTPS, IAM auth, and monitoring. |
+| Observability | Cloud Logging, Cloud Monitoring, Error Reporting | Unified monitoring with dashboards/alerts. |
+| CI/CD | Cloud Build triggers or Cloud Deploy | Managed pipelines and progressive delivery. |
+
+## Suggested Markdown Schema for Agent Instructions
+
+The editor can expose a Markdown-based schema with explicit sections. Below is a starter template to guide authors:
+
+```markdown
+---
+id: customer_support_v1
+version: 2024-05-01
+runtime:
+  engine: agent-engine
+  image: ${AGENT_IMAGE_TAG}
+  environment:
+    - SECRET_REF: projects/${PROJECT_ID}/secrets/customer_support
+    - DATASET_ID: ${DATASET_ID}
+monitoring:
+  alerts:
+    - latency_p95 > 2000ms
+    - error_rate > 1%
+---
+
+# Purpose
+Outline the primary objectives of this agent and key success metrics.
+
+# System Prompt
+```prompt
+You are an empathetic customer support specialist...
+```
+
+# Behavioral Policies
+- Always confirm the customer account.
+- Escalate billing disputes to human agent if unresolved after two exchanges.
+
+# Tools
+| Name | Description | Invocation |
+| --- | --- | --- |
+| `lookup_user` | Queries CRM by email. | `POST https://crm.internal/api/users` |
+| `create_ticket` | Opens Zendesk ticket. | `POST https://zendesk.internal/api/tickets` |
+
+# Test Scenarios
+- `onboarding_flow` (see scenario harness above)
+- `billing_dispute`
+
+# Rollout Checklist
+- ✅ Stakeholder review
+- ✅ QA dry-run passed
+- ✅ Observability dashboards updated
+```
+
+## Pushback & Recommendations
+
+1. **Avoid per-agent hardcoding:** Centralize all endpoint URLs, model names, and secrets. The editor should only reference keys that the backend resolves at deploy time.
+2. **Version every artifact:** Track prompt versions, test suites, and deployment manifests. Consider GitOps (e.g., Config Sync) for auditable changes.
+3. **Add automated guardrails:** Enforce validation rules (naming conventions, required test coverage) before enabling deployment. This prevents drift and encourages quality gates.
+4. **Leverage infrastructure-as-code:** Define Cloud Build triggers, IAM roles, and runtime infrastructure using Terraform or Google Cloud Deploy to maintain reproducibility.
+5. **Establish observability standards:** Require latency/error SLO definitions and integrate with Cloud Monitoring dashboards before promoting to production.
+
+By following this structure, the WYSIWYG editor can remain declarative, auditable, and tightly integrated with ADK Web and the downstream agent engine while keeping operations DRY and cloud-native.


### PR DESCRIPTION
## Summary
- add documentation outlining a proposed Chainlit + ADK WYSIWYG editor architecture
- provide markdown schema, GCP service recommendations, and deployment guardrails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e562ad7a888330897da7b818481578