### PR TITLE
Add documentation inventory and LLM credential guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ dist
 *.files
 
 venv
-.venv
+.venv/
+.chainlit/
 .DS_Store
 
 **/.chainlit/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Guidance for AI Contributors
+
+- Treat the root `.env` (and any `.env.*` variants) as the single source of truth for runtime configuration. Do **not** hardcode secrets or service identifiers in code samples—reference environment variables instead.
+- When documenting workflows, favor reusable commands (e.g., `make` targets or scripts) that can run identically on developer machines, CI, and GCP build systems to preserve DRY principles.
+- Highlight GCP-aligned practices (Secret Manager, Cloud Build, Cloud Run, etc.) whenever you introduce configuration or deployment guidance.
+- Keep documentation concise but actionable: prefer checklists or tables that engineers can follow without guesswork.

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,15 @@ chainlit hello
 
 If this opens the `hello app` in your browser, you're all set!
 
+## 🗂️ Documentation inventory
+
+| File | Purpose |
+| --- | --- |
+| [`README.md`](README.md) | High-level project overview and quickstart commands. |
+| [`docs/local-setup.md`](docs/local-setup.md) | Minimal smoke test to validate local installs using shared `.env` values and reproducible package managers. |
+| [`docs/llms.txt`](docs/llms.txt) | Checklist of LLM provider environment variables to keep in centralized secrets (locally via `.env`, in production via GCP Secret Manager). |
+| [`AGENTS.md`](AGENTS.md) | Guidance for AI contributors to keep workflows DRY and aligned with GCP deployment practices. |
+
 ### Development version
 
 The latest in-development version can be installed straight from GitHub with:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,14 @@
+Chainlit ships with adapters for multiple LLM providers. Keep provider credentials in your shared `.env` files and sync them to
+GCP Secret Manager so they can be mounted in Cloud Run, Cloud Functions, and Cloud Build without duplication.
+
+Recommended environment variables:
+- `OPENAI_API_KEY`
+- `GEMINI_API_KEY`
+- `VERTEX_PROJECT_ID`
+- `VERTEX_LOCATION`
+- `ANTHROPIC_API_KEY`
+- `AZURE_OPENAI_ENDPOINT`
+- `AZURE_OPENAI_KEY`
+
+Load these via tooling such as `direnv` or `dotenvx` locally. In production, attach the same secrets via Secret Manager or Config
+Connector to stay DRY across environments.

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -1,0 +1,60 @@
+# Local Development Smoke Test
+
+This guide documents the minimal steps required to verify that Chainlit starts locally without any custom configuration.
+
+## Prerequisites
+
+- Node.js 18+
+- [pnpm](https://pnpm.io/) (the repo is configured for pnpm workspaces)
+- [uv](https://docs.astral.sh/uv/) for managing the Python environment
+
+We recommend storing any credentials or API keys in a project-level `.env` file and loading them via your shell rather than hardcoding values in code or scripts.
+
+## Steps
+
+1. Install JavaScript dependencies once for the monorepo:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Sync the Python environment inside `backend/`:
+
+   ```bash
+   cd backend
+   uv sync
+   ```
+
+3. Launch the bundled "hello" example to confirm the server boots:
+
+   ```bash
+   uv run chainlit hello
+   ```
+
+   The command creates default config files under `.chainlit/` (which are ignored via `.gitignore`) and serves the app at `http://localhost:8000`.
+
+4. Stop the server with `Ctrl+C` when finished.
+
+## Recommended Next Steps
+
+- **Centralize environment configuration**. Commit a lightweight `.env.example` (or reuse an existing shared config repo) and
+  load it with a tool such as [`direnv`](https://direnv.net/) or [`dotenvx`](https://dotenvx.com/) so every contributor sources the
+  same variables automatically. On GCP, mirror those values in Secret Manager and reference them from Cloud Run, Cloud Functions, or
+  Cloud Build instead of re-declaring them per environment.
+- **Codify the smoke test**. Wrap the commands above in a `make smoke-local` (or Taskfile) target that your CI/CD pipeline can
+  invoke. Using the same entry point locally and in automation keeps the workflow DRY and avoids configuration drift.
+- **Keep installs reproducible**. Prefer `pnpm install --frozen-lockfile` and `uv sync --frozen` once your locks are up to date so
+  the dependencies resolved locally match what you deploy. This prevents accidental upgrades when Cloud Build or GitHub Actions runs
+  the same smoke test.
+- **Bootstrap GCP credentials early**. Run `gcloud auth application-default login` and `gcloud config set project <project-id>` in
+  your local shell (or `.env`) so the hello app can reuse Application Default Credentials when you later connect it to managed
+  services. Keeping these values in `.env` makes it trivial to hydrate the same settings in Secret Manager or Config Connector.
+- **Add continuous verification**. Schedule a lightweight Cloud Build (or GitHub Actions) job that executes the `smoke-local`
+  target on every merge and nightly. This catches lockfile or dependency regressions before they reach production environments.
+
+## Troubleshooting
+
+- If ports are occupied, export `CHAINLIT_PORT` in your shell (for example via `.env`) before running the hello app.
+- For GCP deployments, prefer using Secret Manager or Cloud Run service variables instead of embedding secrets in code. Keeping the workflow `.env`-driven locally makes it easy to map to those services later.
+
+Following these steps keeps the setup DRY by relying on shared package managers and environment variables instead of ad-hoc configuration files.


### PR DESCRIPTION
## Summary
- add repository-level AGENTS guidance to reinforce shared `.env` usage and GCP-aligned workflows
- surface a documentation inventory in the README so contributors can find local setup and LLM credential docs quickly
- introduce `docs/llms.txt` to track the canonical environment variables for LLM providers and recommend Secret Manager mirroring

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e582e7727483309b3759ada803fbc7