### PR TITLE
Install mypy extras for smoke test lint parity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in the values before running local services.
+# These variables mirror the credentials documented in docs/llms.txt so they remain DRY.
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+VERTEX_PROJECT_ID=
+VERTEX_LOCATION=us-central1
+ANTHROPIC_API_KEY=
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_KEY=
+CHAINLIT_PORT=8000
+# Optional values to keep local secrets in sync with GCP Secret Manager.
+GCP_PROJECT_ID=
+CHAINLIT_SECRET_NAME=chainlit-env

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,0 +1,51 @@
+name: Smoke Test
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: '24.3.0'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Prepare dotenv
+        env:
+          CHAINLIT_ENV_CONTENT: ${{ secrets.CHAINLIT_ENV_CONTENT }}
+        run: |
+          set -euo pipefail
+          if [ -n "${CHAINLIT_ENV_CONTENT:-}" ]; then
+            printf '%s' "${CHAINLIT_ENV_CONTENT}" > .env
+          else
+            python3 scripts/start_local.py --non-interactive
+          fi
+
+      - name: Run smoke test
+        run: python3 scripts/smoke_test.py

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,14 +48,37 @@ chainlit hello
 
 If this opens the `hello app` in your browser, you're all set!
 
+
+### Bootstrap the local monorepo
+
+Clone this repository and populate the shared `.env` file before running any of the smoke tests:
+
+```sh
+python3 scripts/start_local.py --smoke-test
+```
+
+The helper script mirrors [`docs/local-setup.md`](../docs/local-setup.md) by:
+
+1. Reading the credential inventory from [`.env.example`](../.env.example) so API keys remain DRY across developers and CI.
+2. Reusing any values already set in `.env` or exported in your shell, prompting only for the remainder (press <kbd>Enter</kbd> to keep documented defaults or leave them blank). Pass `--non-interactive` to skip prompts entirely in automation while still surfacing any empty secrets at the end.
+3. Running [`scripts/smoke_test.py`](../scripts/smoke_test.py) when invoked with `--smoke-test` so the repository matches the documented workflow across local shells, GitHub Actions, and Cloud Build. The helper waits for `chainlit hello --ci --headless` to report readiness, verifies it serves HTTP, and tears it down automatically so automation never hangs. It still falls back to `pnpm install`/`uv sync --extra mypy` without `--frozen` if drift is detected and reminds you to reconcile the lockfiles so mypy stubs remain available for Husky hooks.
+
+On GCP we recommend storing the same variables in Secret Manager and mounting them into Cloud Run/Cloud Functions to avoid duplicating secrets per environment. After generating `.env`, mirror it to Secret Manager so automation stays DRY:
+
+```sh
+python3 scripts/sync_env_to_gcp.py --create
+```
+
+The sync helper writes the exact `.env` content documented above, enabling Cloud Build (see [`cloudbuild/smoke-test.yaml`](../cloudbuild/smoke-test.yaml)) and GitHub Actions to run the shared smoke test without redefining secrets.
+
 ## 🗂️ Documentation inventory
 
 | File | Purpose |
 | --- | --- |
-| [`README.md`](README.md) | High-level project overview and quickstart commands. |
-| [`docs/local-setup.md`](docs/local-setup.md) | Minimal smoke test to validate local installs using shared `.env` values and reproducible package managers. |
-| [`docs/llms.txt`](docs/llms.txt) | Checklist of LLM provider environment variables to keep in centralized secrets (locally via `.env`, in production via GCP Secret Manager). |
-| [`AGENTS.md`](AGENTS.md) | Guidance for AI contributors to keep workflows DRY and aligned with GCP deployment practices. |
+| [`README.md`](../README.md) | High-level project overview and quickstart commands. |
+| [`docs/local-setup.md`](../docs/local-setup.md) | Minimal smoke test to validate local installs using shared `.env` values and reproducible package managers. |
+| [`docs/llms.txt`](../docs/llms.txt) | Checklist of LLM provider environment variables to keep in centralized secrets (locally via `.env`, in production via GCP Secret Manager). |
+| [`AGENTS.md`](../AGENTS.md) | Guidance for AI contributors to keep workflows DRY and aligned with GCP deployment practices. |
 
 ### Development version
 

--- a/cloudbuild/smoke-test.yaml
+++ b/cloudbuild/smoke-test.yaml
@@ -1,0 +1,43 @@
+# Run the shared smoke test inside Cloud Build using the same helper scripts as local developers.
+
+timeout: 1800s
+
+substitutions:
+  _CHAINLIT_SECRET_NAME: chainlit-env
+
+steps:
+  - id: "Run smoke test"
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: bash
+    env:
+      - CLOUDSDK_CORE_PROJECT=${PROJECT_ID}
+    args:
+      - -c
+      - |
+        set -euxo pipefail
+
+        if [ -z "${CHAINLIT_ENV_CONTENT:-}" ]; then
+          echo "Secret ${_CHAINLIT_SECRET_NAME} is empty or unavailable" >&2
+          exit 1
+        fi
+
+        printf '%s' "$CHAINLIT_ENV_CONTENT" > .env
+
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y curl python3 python3-pip python3-venv build-essential
+
+        curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+        DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+
+        corepack enable
+        corepack prepare pnpm@9 --activate
+
+        python3 -m pip install --upgrade pip
+        python3 -m pip install uv
+
+        python3 scripts/smoke_test.py
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/${PROJECT_ID}/secrets/${_CHAINLIT_SECRET_NAME}/versions/latest
+      env: CHAINLIT_ENV_CONTENT

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,5 +1,6 @@
-Chainlit ships with adapters for multiple LLM providers. Keep provider credentials in your shared `.env` files and sync them to
-GCP Secret Manager so they can be mounted in Cloud Run, Cloud Functions, and Cloud Build without duplication.
+Chainlit ships with adapters for multiple LLM providers. Keep provider credentials in your shared `.env` files (see
+[`.env.example`](../.env.example)) and sync them to GCP Secret Manager so they can be mounted in Cloud Run, Cloud Functions, and
+Cloud Build without duplication.
 
 Recommended environment variables:
 - `OPENAI_API_KEY`
@@ -10,5 +11,12 @@ Recommended environment variables:
 - `AZURE_OPENAI_ENDPOINT`
 - `AZURE_OPENAI_KEY`
 
-Load these via tooling such as `direnv` or `dotenvx` locally. In production, attach the same secrets via Secret Manager or Config
-Connector to stay DRY across environments.
+Load these via tooling such as `direnv` or `dotenvx` locally. The
+[`scripts/start_local.py`](../scripts/start_local.py) helper reads this
+inventory, reuses any values already exported in your shell, and prompts only
+for missing entries so the configuration stays DRY. Pass `--non-interactive`
+when you want automated jobs to accept defaults while still warning about empty
+secrets. Mirror the populated `.env` to GCP with
+[`scripts/sync_env_to_gcp.py`](../scripts/sync_env_to_gcp.py) so Secret Manager,
+Cloud Build, and GitHub Actions load the exact same credentials without
+duplication.

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -12,45 +12,103 @@ We recommend storing any credentials or API keys in a project-level `.env` file 
 
 ## Steps
 
-1. Install JavaScript dependencies once for the monorepo:
+1. Run the bootstrap helper to collect environment variables defined in
+   [`.env.example`](../.env.example) and optionally execute the smoke test
+   automatically:
 
    ```bash
-   pnpm install
+   python3 scripts/start_local.py --smoke-test
    ```
 
-2. Sync the Python environment inside `backend/`:
+   The helper reuses any values already stored in `.env` or exported in your
+   current shell so secrets stay DRY across tools like `direnv`. Pass
+   `--non-interactive` (for example in CI) to accept defaults automatically
+   while still warning when required values remain blank and summarizing any
+   fields you should fill later. The `--smoke-test` flag now defers to
+   [`scripts/smoke_test.py`](../scripts/smoke_test.py) so local shells, GitHub
+   Actions, and Cloud Build all run the exact same workflow. The helper waits
+   for `chainlit hello --ci --headless` to report readiness, probes the served
+   URL, and then shuts the process down automatically so automation never hangs.
+   If you prefer to run the commands manually, omit the flag and continue with
+   the next steps or call the smoke test helper directly:
+
+   ```bash
+   python3 scripts/smoke_test.py
+   ```
+
+   Pass `--timeout` to adjust how long the helper should wait for readiness.
+
+2. Install JavaScript dependencies once for the monorepo:
+
+   ```bash
+   pnpm install --frozen-lockfile
+   ```
+
+   If your lockfile is out of date the helper will fall back to `pnpm install`
+   and prompt you to reconcile the change.
+
+3. Sync the Python environment inside `backend/`:
 
    ```bash
    cd backend
-   uv sync
+   uv sync --frozen --extra mypy
    ```
 
-3. Launch the bundled "hello" example to confirm the server boots:
+   As above, the helper automatically retries with `uv sync --extra mypy`—
+   dropping the `--frozen` flag on a second attempt—when drift is detected so
+   you can update the lock under version control. Installing
+   the `mypy` extra upfront gives the Husky `pnpm run lintPython` hook the type
+   stubs it needs to pass on a clean checkout.
+
+   > Need a slimmer runtime check? Run `python3 scripts/smoke_test.py --no-python-extras`
+   > to skip optional extras entirely or add `--python-extra <name>` when you
+   > want to install additional bundles beyond `mypy`.
+
+4. Launch the bundled "hello" example to confirm the server boots:
 
    ```bash
    uv run chainlit hello
    ```
 
-   The command creates default config files under `.chainlit/` (which are ignored via `.gitignore`) and serves the app at `http://localhost:8000`.
+   The command creates default config files under `.chainlit/` (which are
+   ignored via `.gitignore`) and serves the app at `http://localhost:8000`.
 
-4. Stop the server with `Ctrl+C` when finished.
+5. When running the command manually, stop the server with `Ctrl+C` when
+   finished. The smoke test helper shuts the process down for you.
+
+6. (Optional) Mirror the populated `.env` file to GCP Secret Manager so Cloud
+   Build and other environments reuse the same configuration:
+
+   ```bash
+   python3 scripts/sync_env_to_gcp.py --create
+   ```
+
+   The helper reads [`.env.example`](../.env.example) to determine which keys
+   to upload, skips empty values by default, and provisions the secret when you
+   pass `--create`. Set `GCP_PROJECT_ID` and `CHAINLIT_SECRET_NAME` in `.env`
+   (or export them) to avoid repeating flags.
 
 ## Recommended Next Steps
 
 - **Centralize environment configuration**. Commit a lightweight `.env.example` (or reuse an existing shared config repo) and
   load it with a tool such as [`direnv`](https://direnv.net/) or [`dotenvx`](https://dotenvx.com/) so every contributor sources the
-  same variables automatically. On GCP, mirror those values in Secret Manager and reference them from Cloud Run, Cloud Functions, or
-  Cloud Build instead of re-declaring them per environment.
-- **Codify the smoke test**. Wrap the commands above in a `make smoke-local` (or Taskfile) target that your CI/CD pipeline can
-  invoke. Using the same entry point locally and in automation keeps the workflow DRY and avoids configuration drift.
-- **Keep installs reproducible**. Prefer `pnpm install --frozen-lockfile` and `uv sync --frozen` once your locks are up to date so
-  the dependencies resolved locally match what you deploy. This prevents accidental upgrades when Cloud Build or GitHub Actions runs
-  the same smoke test.
+  same variables automatically. On GCP, mirror those values in Secret Manager with
+  [`scripts/sync_env_to_gcp.py`](../scripts/sync_env_to_gcp.py) and reference the secret from Cloud Run, Cloud Functions, or Cloud
+  Build instead of re-declaring them per environment.
+- **Codify the smoke test**. The repository now exposes [`scripts/smoke_test.py`](../scripts/smoke_test.py) so local shells, GitHub
+  Actions, and Cloud Build execute the same sequence. Use it directly or wrap it in a task runner (for example `make` or `just`) to
+  keep orchestration DRY.
+- **Keep installs reproducible**. The bootstrap helper already prefers
+  `pnpm install --frozen-lockfile` and `uv sync --frozen --extra mypy` so local setups and
+  CI resolve the same dependencies. When those commands fail, reconcile the
+  lockfiles (or intentionally fall back) rather than committing ad-hoc
+  upgrades.
 - **Bootstrap GCP credentials early**. Run `gcloud auth application-default login` and `gcloud config set project <project-id>` in
   your local shell (or `.env`) so the hello app can reuse Application Default Credentials when you later connect it to managed
   services. Keeping these values in `.env` makes it trivial to hydrate the same settings in Secret Manager or Config Connector.
-- **Add continuous verification**. Schedule a lightweight Cloud Build (or GitHub Actions) job that executes the `smoke-local`
-  target on every merge and nightly. This catches lockfile or dependency regressions before they reach production environments.
+- **Add continuous verification**. Wire the new smoke test into automation. We provide a reusable [GitHub Actions workflow](../.github/workflows/smoke-test.yaml) and a
+  [Cloud Build configuration](../cloudbuild/smoke-test.yaml) so merges and nightly jobs exercise the same helper used by
+  contributors. This catches lockfile or dependency regressions before they reach production environments.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "pnpm run lintUi && pnpm run lintPython",
     "lintUi": "pnpm run --parallel lint",
     "formatUi": "pnpm run --parallel format",
-    "lintPython": "cd backend && uv run dmypy run -- chainlit/ tests/",
+    "lintPython": "cd backend && uv run --extra mypy dmypy run -- chainlit/ tests/",
     "formatPython": "black `git ls-files | grep '.py$'` && isort --profile=black .",
     "build:libs": "cd libs/react-client && pnpm run build && cd ../copilot && pnpm run build",
     "buildUi": "pnpm build:libs && cd frontend && pnpm run build"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,10 @@
+"""Shared helpers for repository scripts."""
+
+from pathlib import Path
+
+# The repository root acts as the anchor for all script paths so helpers can
+# be reused from local shells, CI, or Cloud Build without recomputing the
+# location.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+__all__ = ["REPO_ROOT"]

--- a/scripts/_command_utils.py
+++ b/scripts/_command_utils.py
@@ -1,0 +1,42 @@
+"""Lightweight wrappers for running shell commands from helper scripts."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+def run_command(command: Sequence[str], cwd: Path | None = None) -> bool:
+    """Execute a command, returning ``True`` on success."""
+
+    print(f"\n→ {' '.join(command)}")
+    try:
+        subprocess.run(command, cwd=cwd, check=True)
+    except FileNotFoundError:
+        print(
+            f"  ! Command '{command[0]}' is not available. Install it or rerun without the current option."
+        )
+        return False
+    except subprocess.CalledProcessError as exc:
+        print(f"  ! Command failed with exit code {exc.returncode}.")
+        return False
+    return True
+
+
+def attempt_with_fallback(
+    primary: Sequence[str],
+    fallback: Sequence[str],
+    *,
+    cwd: Path | None = None,
+) -> bool:
+    """Run ``primary`` and fall back to ``fallback`` if it fails."""
+
+    if run_command(primary, cwd=cwd):
+        return True
+
+    print(f"  ! Falling back to '{' '.join(fallback)}' for developer convenience.")
+    return run_command(fallback, cwd=cwd)
+
+
+__all__ = ["attempt_with_fallback", "run_command"]

--- a/scripts/_env.py
+++ b/scripts/_env.py
@@ -1,0 +1,72 @@
+"""Helpers for reading and writing repository `.env` files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from . import REPO_ROOT
+
+ENV_TEMPLATE = REPO_ROOT / ".env.example"
+ENV_FILE = REPO_ROOT / ".env"
+
+
+def parse_env_file(path: Path) -> Dict[str, str]:
+    """Return key/value pairs from an env-style file."""
+
+    values: Dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    for raw_line in path.read_text().splitlines():
+        if raw_line.strip().startswith("#") or "=" not in raw_line:
+            continue
+        key, value = raw_line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def merge_template(
+    template_lines: Iterable[str],
+    values: Dict[str, str],
+    extras: List[str],
+) -> str:
+    """Render env content based on template lines and provided values."""
+
+    rendered: List[str] = []
+    for raw_line in template_lines:
+        if raw_line.strip().startswith("#") or "=" not in raw_line:
+            rendered.append(raw_line.rstrip())
+            continue
+        key = raw_line.split("=", 1)[0].strip()
+        rendered.append(f"{key}={values.get(key, '')}")
+
+    if extras:
+        rendered.append("")
+        rendered.append("# Additional entries preserved from existing .env")
+        rendered.extend(extras)
+
+    return "\n".join(rendered).strip() + "\n"
+
+
+def preserve_extra_lines(
+    existing_lines: Iterable[str], template_keys: Iterable[str]
+) -> List[str]:
+    template_key_set = {key.strip() for key in template_keys}
+    extras: List[str] = []
+    for raw_line in existing_lines:
+        if raw_line.strip().startswith("#") or "=" not in raw_line:
+            continue
+        key = raw_line.split("=", 1)[0].strip()
+        if key not in template_key_set:
+            extras.append(raw_line.rstrip())
+    return extras
+
+
+__all__ = [
+    "ENV_FILE",
+    "ENV_TEMPLATE",
+    "merge_template",
+    "parse_env_file",
+    "preserve_extra_lines",
+]

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Execute the standard Chainlit smoke test across environments."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Optional, Sequence
+from urllib.error import URLError
+from urllib.request import urlopen
+
+if __package__ is None:  # pragma: no cover - executed when run as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import REPO_ROOT
+from scripts._command_utils import attempt_with_fallback
+
+READINESS_PHRASE = "Your app is available at"
+DEFAULT_PYTHON_EXTRAS: tuple[str, ...] = ("mypy",)
+
+
+def _build_uv_sync_command(*, frozen: bool, extras: Sequence[str]) -> list[str]:
+    """Construct a ``uv sync`` command that installs optional extras."""
+
+    command: list[str] = ["uv", "sync"]
+    if frozen:
+        command.append("--frozen")
+    for extra in extras:
+        command.extend(["--extra", extra])
+    return command
+
+
+def _probe_http(url: str, timeout: float) -> bool:
+    """Poll ``url`` until it responds with a 2xx/3xx status."""
+
+    deadline = time.monotonic() + timeout
+    last_error: Optional[Exception] = None
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(url) as response:  # nosec - internal smoke test
+                if 200 <= response.status < 400:
+                    return True
+        except URLError as exc:  # pragma: no cover - exercised in runtime smoke tests
+            last_error = exc
+            time.sleep(0.5)
+        except Exception as exc:  # pragma: no cover - broad guard for CI environments
+            last_error = exc
+            time.sleep(0.5)
+
+    if last_error:
+        print(f"  ! HTTP readiness probe failed for {url}: {last_error}")
+    return False
+
+
+def _terminate_process(
+    process: subprocess.Popen[bytes], *, timeout: float = 10.0
+) -> None:
+    """Attempt to stop ``process`` gracefully, falling back to kill."""
+
+    if process.poll() is not None:
+        return
+
+    process.terminate()
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:  # pragma: no cover - defensive guard
+        process.kill()
+        process.wait(timeout=timeout)
+
+
+def _run_chainlit_hello(timeout: float) -> bool:
+    """Launch ``chainlit hello`` and verify it serves HTTP before shutting down."""
+
+    command = ["uv", "run", "chainlit", "hello", "--ci", "--headless"]
+    print(f"\n→ {' '.join(command)}")
+
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except FileNotFoundError:
+        print(
+            "  ! Command 'uv' is not available. Install uv before running the smoke test."
+        )
+        return False
+
+    host = os.environ.get("CHAINLIT_HOST", "127.0.0.1")
+    raw_port = os.environ.get("CHAINLIT_PORT", "8000")
+    try:
+        port = int(raw_port)
+    except ValueError:
+        print(
+            "  ! CHAINLIT_PORT must be an integer. Update your environment configuration and rerun the smoke test."
+        )
+        return False
+    base_url = f"http://{host}:{port}/"
+
+    readiness_deadline = time.monotonic() + timeout
+    ready = False
+    assert process.stdout is not None
+
+    try:
+        while time.monotonic() < readiness_deadline:
+            if process.poll() is not None:
+                break
+
+            line = process.stdout.readline()
+            if line:
+                print(f"   {line.rstrip()}")
+                if READINESS_PHRASE in line:
+                    ready = True
+                    break
+            else:
+                time.sleep(0.1)
+
+        if not ready:
+            print(
+                "  ! Chainlit did not report readiness before the timeout elapsed. "
+                "Check the logs above for details."
+            )
+            return False
+
+        if not _probe_http(base_url, timeout=15):
+            return False
+
+        print(f"   Confirmed Chainlit is serving {base_url}. Shutting it down...")
+        return True
+    finally:
+        with suppress(Exception):
+            _terminate_process(process)
+        with suppress(Exception):
+            process.stdout.close()
+
+
+def run_smoke_test(
+    *,
+    install: bool = True,
+    timeout: float = 120.0,
+    python_extras: Sequence[str] | None = None,
+) -> bool:
+    """Run pnpm/uv installs and verify ``chainlit hello`` serves traffic.
+
+    By default the helper syncs the ``mypy`` extra so dmypy has the stubs it
+    needs for the Husky `pnpm run lintPython` hook. Override ``python_extras``
+    to install a custom set of extras or pass an empty tuple to skip them
+    entirely.
+    """
+
+    extras = tuple(python_extras) if python_extras is not None else DEFAULT_PYTHON_EXTRAS
+    success = True
+    if install:
+        js_success = attempt_with_fallback(
+            ["pnpm", "install", "--frozen-lockfile"],
+            ["pnpm", "install"],
+            cwd=REPO_ROOT,
+        )
+        py_success = attempt_with_fallback(
+            _build_uv_sync_command(frozen=True, extras=extras),
+            _build_uv_sync_command(frozen=False, extras=extras),
+            cwd=REPO_ROOT / "backend",
+        )
+        success = js_success and py_success
+        if not success:
+            print(
+                "\nDependency installation failed. Resolve the issues above and rerun the smoke test."
+            )
+            return False
+
+    return _run_chainlit_hello(timeout)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the repository smoke test so local, CI, and Cloud Build workflows stay DRY."
+    )
+    parser.add_argument(
+        "--skip-installs",
+        action="store_true",
+        help="Skip pnpm install and uv sync (useful when dependencies are already prepared).",
+    )
+    parser.add_argument(
+        "--python-extra",
+        dest="python_extras",
+        action="append",
+        help=(
+            "Install the given pyproject extra via `uv sync --extra` before running the smoke test. "
+            "Provide multiple times to include more than one extra. Defaults to 'mypy' so dmypy "
+            "has the necessary type stubs."
+        ),
+    )
+    parser.add_argument(
+        "--no-python-extras",
+        action="store_true",
+        help="Skip installing additional Python extras when syncing dependencies.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="Seconds to wait for Chainlit to report readiness before failing the smoke test.",
+    )
+    args = parser.parse_args()
+
+    extras_arg: Sequence[str] | None
+    if args.no_python_extras:
+        extras_arg = ()
+    elif args.python_extras:
+        extras_arg = tuple(args.python_extras)
+    else:
+        extras_arg = None
+
+    success = run_smoke_test(
+        install=not args.skip_installs,
+        timeout=args.timeout,
+        python_extras=extras_arg,
+    )
+    if success:
+        print(
+            "\nSmoke test completed successfully. Chainlit was started, probed, and "
+            "shut down automatically."
+        )
+    else:
+        print(
+            "\nOne or more smoke test steps failed. Resolve the issue and rerun the helper "
+            "or execute the commands manually."
+        )
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/start_local.py
+++ b/scripts/start_local.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Bootstrap the local Chainlit development environment."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+if __package__ is None:  # pragma: no cover - executed when run as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import REPO_ROOT
+from scripts._env import (
+    ENV_FILE,
+    ENV_TEMPLATE,
+    merge_template,
+    parse_env_file,
+    preserve_extra_lines,
+)
+from scripts.smoke_test import run_smoke_test
+
+
+def _collect_env_values(non_interactive: bool) -> Tuple[Dict[str, str], List[str]]:
+    template_values = parse_env_file(ENV_TEMPLATE)
+    if not template_values:
+        raise SystemExit(
+            "Expected .env.example to describe environment variables. "
+            "Please add variables to the template before running this script."
+        )
+
+    existing_values = parse_env_file(ENV_FILE)
+    collected: Dict[str, str] = {}
+    missing_required: List[str] = []
+
+    mode_msg = "non-interactively" if non_interactive else "interactively"
+    print(
+        "Configuring environment variables defined in .env.example "
+        f"{mode_msg}. Press Enter to keep defaults when prompted."
+    )
+    for key, default in template_values.items():
+        current = existing_values.get(key, "")
+        if current:
+            collected[key] = current
+            print(f"- {key}: using existing value")
+            continue
+
+        env_value = os.environ.get(key, "")
+        if env_value:
+            collected[key] = env_value
+            print(f"- {key}: using value from current shell environment")
+            continue
+
+        prompt = f"Enter value for {key}"
+        if default:
+            prompt += f" [{default}]"
+        prompt += ": "
+
+        if non_interactive:
+            value = default
+        else:
+            try:
+                value = input(prompt).strip()
+            except KeyboardInterrupt:  # pragma: no cover - interactive guard
+                print("\nSetup interrupted by user.")
+                raise SystemExit(1)
+
+        if not value:
+            if default:
+                value = default
+            else:
+                missing_required.append(key)
+        collected[key] = value
+    return collected, missing_required
+
+
+def write_env_file(values: Dict[str, str]) -> None:
+    template_lines = ENV_TEMPLATE.read_text().splitlines()
+    extras = preserve_extra_lines(
+        ENV_FILE.read_text().splitlines() if ENV_FILE.exists() else [],
+        parse_env_file(ENV_TEMPLATE).keys(),
+    )
+    content = merge_template(template_lines, values, extras)
+    try:
+        ENV_FILE.write_text(content)
+    except OSError as exc:
+        raise SystemExit(
+            f"Failed to write {ENV_FILE.relative_to(REPO_ROOT)}: {exc}"
+        ) from exc
+    print(f"Updated {ENV_FILE.relative_to(REPO_ROOT)} with {len(values)} variables.")
+
+
+def _summarize_missing(missing: Iterable[str]) -> None:
+    missing_list = list(missing)
+    if not missing_list:
+        return
+
+    print("\n⚠️  The following variables remain empty in .env:")
+    for key in missing_list:
+        print(f"   - {key}")
+    print(
+        "Populate them later (for example via `direnv`, Secret Manager, or by rerunning this script) "
+        "before connecting to providers that require them."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare a local Chainlit development environment."
+    )
+    parser.add_argument(
+        "--smoke-test",
+        action="store_true",
+        help="Run pnpm install, uv sync, and uv run chainlit hello after writing .env.",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Use defaults and existing environment variables without prompting. Intended for CI or bootstrap scripts.",
+    )
+    args = parser.parse_args()
+
+    if not ENV_TEMPLATE.exists():
+        raise SystemExit(
+            "Missing .env.example. Create it with the required variables before running this script."
+        )
+
+    values, missing = _collect_env_values(non_interactive=args.non_interactive)
+    write_env_file(values)
+    _summarize_missing(missing)
+
+    # Ensure child processes inherit the configured environment variables.
+    for key, value in values.items():
+        os.environ[key] = value
+
+    if args.smoke_test:
+        success = run_smoke_test()
+        if success:
+            print(
+                "\nSmoke test completed successfully. Chainlit was started, probed, and "
+                "shut down automatically."
+            )
+        else:
+            print(
+                "\nOne or more smoke test steps failed. Resolve the issue and rerun the script "
+                "or execute the commands manually."
+            )
+            raise SystemExit(1)
+    else:
+        print(
+            "\nNext steps:\n"
+            "  1. pnpm install --frozen-lockfile\n"
+            "  2. cd backend && uv sync --frozen --extra mypy\n"
+            "  3. uv run chainlit hello\n"
+            "Run with --smoke-test or python3 scripts/smoke_test.py to execute these commands automatically."
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit as exc:
+        if exc.code not in (0, 1):
+            raise
+        sys.exit(exc.code)

--- a/scripts/sync_env_to_gcp.py
+++ b/scripts/sync_env_to_gcp.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Mirror the local `.env` file into GCP Secret Manager for automation."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+if __package__ is None:  # pragma: no cover - executed when run as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import REPO_ROOT
+from scripts._env import ENV_FILE, ENV_TEMPLATE, parse_env_file
+
+DEFAULT_PROJECT_ENV = "GCP_PROJECT_ID"
+DEFAULT_SECRET_ENV = "CHAINLIT_SECRET_NAME"
+
+
+def _build_payload(
+    template: Dict[str, str],
+    values: Dict[str, str],
+    *,
+    include_empty: bool,
+) -> List[str]:
+    """Render a Secret Manager payload honoring the template order."""
+
+    payload: List[str] = []
+    for key in template:
+        value = values.get(key, "")
+        if value or include_empty:
+            payload.append(f"{key}={value}")
+
+    for key, value in values.items():
+        if key in template:
+            continue
+        if value or include_empty:
+            payload.append(f"{key}={value}")
+
+    return payload
+
+
+def _run_gcloud(args: Iterable[str], *, capture_output: bool = False) -> subprocess.CompletedProcess:
+    command = ["gcloud", *args]
+    print(f"\n→ {' '.join(command)}")
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=capture_output,
+        text=True,
+    )
+
+
+def _secret_exists(project: str, secret: str) -> bool:
+    result = _run_gcloud(
+        [
+            "secrets",
+            "describe",
+            secret,
+            "--project",
+            project,
+            "--format=value(name)",
+            "--quiet",
+        ],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _create_secret(project: str, secret: str) -> None:
+    result = _run_gcloud(
+        [
+            "secrets",
+            "create",
+            secret,
+            "--project",
+            project,
+            "--replication-policy=automatic",
+        ]
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"Failed to create secret '{secret}' in project '{project}'.")
+
+
+def _add_secret_version(project: str, secret: str, data_path: Path) -> None:
+    result = _run_gcloud(
+        [
+            "secrets",
+            "versions",
+            "add",
+            secret,
+            "--project",
+            project,
+            f"--data-file={data_path}",
+        ]
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"Failed to add a new version for secret '{secret}'. See the gcloud output above for details."
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload .env values to Secret Manager so Cloud Build and CI reuse the same configuration."
+    )
+    parser.add_argument(
+        "--project",
+        default=None,
+        help=(
+            "GCP project ID. Defaults to the environment variable "
+            f"{DEFAULT_PROJECT_ENV} or VERTEX_PROJECT_ID if available."
+        ),
+    )
+    parser.add_argument(
+        "--secret",
+        default=None,
+        help=(
+            "Secret Manager name that should store the .env payload. Defaults to the environment variable "
+            f"{DEFAULT_SECRET_ENV}."
+        ),
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=ENV_FILE,
+        help="Path to the .env file to mirror (defaults to the repository .env).",
+    )
+    parser.add_argument(
+        "--include-empty",
+        action="store_true",
+        help="Include keys with empty values. By default empty fields are omitted to avoid overwriting populated secrets.",
+    )
+    parser.add_argument(
+        "--create",
+        action="store_true",
+        help="Create the Secret Manager entry if it does not exist yet.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the payload instead of uploading it. Useful for validating which keys will sync.",
+    )
+    args = parser.parse_args()
+
+    if shutil.which("gcloud") is None:
+        raise SystemExit("gcloud CLI is required. Install it and authenticate before syncing secrets.")
+
+    project = (
+        args.project
+        or os.environ.get(DEFAULT_PROJECT_ENV)
+        or os.environ.get("VERTEX_PROJECT_ID")
+    )
+    if not project:
+        raise SystemExit(
+            "Set --project, GCP_PROJECT_ID, or VERTEX_PROJECT_ID so the script knows which project to target."
+        )
+
+    secret = args.secret or os.environ.get(DEFAULT_SECRET_ENV)
+    if not secret:
+        raise SystemExit(
+            "Set --secret or the CHAINLIT_SECRET_NAME environment variable to identify the Secret Manager entry."
+        )
+
+    if not ENV_TEMPLATE.exists():
+        raise SystemExit("Missing .env.example. Populate it before mirroring secrets to GCP.")
+
+    template_values = parse_env_file(ENV_TEMPLATE)
+    if not template_values:
+        raise SystemExit(".env.example is empty. Define the expected keys before syncing to Secret Manager.")
+
+    source_path = args.source if args.source.is_absolute() else REPO_ROOT / args.source
+    if not source_path.exists():
+        raise SystemExit(f"{source_path} does not exist. Run scripts/start_local.py first to generate it.")
+
+    env_values = parse_env_file(source_path)
+    if not env_values:
+        raise SystemExit(f"No key/value pairs found in {source_path}. Populate it before syncing to GCP.")
+
+    missing_required = [key for key in template_values if not env_values.get(key)]
+    if missing_required and not args.include_empty:
+        print(
+            "\n⚠️  The following keys are empty and will be skipped. Rerun the local bootstrapper or pass --include-empty if you "
+            "intend to clear them in Secret Manager:"
+        )
+        for key in missing_required:
+            print(f"   - {key}")
+
+    payload_lines = _build_payload(template_values, env_values, include_empty=args.include_empty)
+    if not payload_lines:
+        raise SystemExit("Nothing to upload after filtering empty values. Populate .env and rerun.")
+
+    if args.dry_run:
+        print("\nDry run – payload that would be uploaded:\n")
+        print("\n".join(payload_lines))
+        return
+
+    if not _secret_exists(project, secret):
+        if not args.create:
+            raise SystemExit(
+                f"Secret '{secret}' does not exist in project '{project}'. Pass --create to provision it automatically."
+            )
+        _create_secret(project, secret)
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        tmp.write("\n".join(payload_lines) + "\n")
+        tmp_path = Path(tmp.name)
+
+    try:
+        _add_secret_version(project, secret, tmp_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    print(
+        "\nSecret Manager updated successfully. Reference this secret from Cloud Build via availableSecrets and write the "
+        "payload to .env before invoking scripts/smoke_test.py."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure the shared smoke test syncs the `mypy` extra by default and allow callers to opt out or add more extras
- update start_local guidance and local setup docs to reflect the extra install and document the new CLI flags
- run the Husky `lintPython` script with `uv run --extra mypy` so dmypy always has the type stubs it needs

## Testing
- python3 scripts/start_local.py --non-interactive
- python3 scripts/smoke_test.py --skip-installs --no-python-extras --timeout 5 *(expected failure in this environment because Chainlit dependencies are not provisioned yet)*

------
https://chatgpt.com/codex/tasks/task_e_68e58619499c8330800378ccebd7de4c