### PR TITLE
Align gcloud project configuration with shared .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,23 @@
 # Copy this file to .env and fill in the values before running local services.
-# These variables mirror the credentials documented in docs/llms.txt so they remain DRY.
+# Keep these values in sync with Secret Manager so Cloud Build, Cloud Run, and
+# local shells all source the same configuration. Optional keys can remain empty
+# until you enable the related integration. See docs/environment-variables.md
+# for a complete feature-by-feature checklist.
+
+# ---------------------------------------------------------------------------
+# Core Chainlit runtime configuration
+# ---------------------------------------------------------------------------
+CHAINLIT_HOST=127.0.0.1
+CHAINLIT_PORT=8000
+CHAINLIT_URL=
+CHAINLIT_ROOT_PATH=
+CHAINLIT_DEBUG=
+CHAINLIT_AUTH_SECRET=
+CHAINLIT_CUSTOM_AUTH=
+
+# ---------------------------------------------------------------------------
+# LLM provider credentials
+# ---------------------------------------------------------------------------
 OPENAI_API_KEY=
 GEMINI_API_KEY=
 VERTEX_PROJECT_ID=
@@ -7,7 +25,54 @@ VERTEX_LOCATION=us-central1
 ANTHROPIC_API_KEY=
 AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_KEY=
-CHAINLIT_PORT=8000
-# Optional values to keep local secrets in sync with GCP Secret Manager.
+
+# ---------------------------------------------------------------------------
+# Messaging connectors
+# ---------------------------------------------------------------------------
+DISCORD_BOT_TOKEN=
+SLACK_BOT_TOKEN=
+SLACK_SIGNING_SECRET=
+SLACK_WEBSOCKET_TOKEN=
+TEAMS_APP_ID=
+TEAMS_APP_PASSWORD=
+
+# ---------------------------------------------------------------------------
+# Persistence and storage
+# ---------------------------------------------------------------------------
+DATABASE_URL=
+BUCKET_NAME=
+DEV_AWS_ENDPOINT=
+AWS_REGION=us-east-1
+LITERAL_API_KEY=
+LITERAL_API_URL=
+
+# ---------------------------------------------------------------------------
+# OAuth providers (fill in the ones you enable)
+# ---------------------------------------------------------------------------
+OAUTH_GITHUB_CLIENT_ID=
+OAUTH_GITHUB_CLIENT_SECRET=
+OAUTH_GOOGLE_CLIENT_ID=
+OAUTH_GOOGLE_CLIENT_SECRET=
+OAUTH_OKTA_DOMAIN=
+OAUTH_OKTA_CLIENT_ID=
+OAUTH_OKTA_CLIENT_SECRET=
+OAUTH_AUTH0_DOMAIN=
+OAUTH_AUTH0_CLIENT_ID=
+OAUTH_AUTH0_CLIENT_SECRET=
+OAUTH_COGNITO_DOMAIN=
+OAUTH_COGNITO_CLIENT_ID=
+OAUTH_COGNITO_CLIENT_SECRET=
+OAUTH_GENERIC_CLIENT_ID=
+OAUTH_GENERIC_CLIENT_SECRET=
+OAUTH_GENERIC_AUTH_URL=
+OAUTH_GENERIC_TOKEN_URL=
+OAUTH_GENERIC_USER_INFO_URL=
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# GCP Secret Manager integration (leave blank to skip automatic sync)
+# Run `python3 scripts/set_gcloud_project.py` after editing these values to keep the gcloud CLI aligned.
+# ---------------------------------------------------------------------------
 GCP_PROJECT_ID=
 CHAINLIT_SECRET_NAME=chainlit-env
+GCP_SECRET_MANAGER_REPLICA_LOCATION=

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,136 @@
+# Environment Variable Checklist
+
+This reference captures the environment variables Chainlit supports so you can
+keep configuration DRY across local shells, CI, and GCP deployments. Populate
+[`.env`](../.env.example) locally, sync it to Secret Manager with
+[`scripts/sync_env_to_gcp.py`](../scripts/sync_env_to_gcp.py), and mount the same
+secret in Cloud Build, Cloud Run, or Cloud Functions to avoid drift.
+
+> **Tip:** Store production values in Google Secret Manager and grant Cloud Run
+> and Cloud Build service accounts access instead of pasting credentials into
+> build steps. Locally, rely on tools like `direnv` or `dotenvx` to hydrate the
+> same `.env` file.
+
+## Core runtime
+
+| Variable | Required | Purpose | GCP guidance |
+| --- | --- | --- | --- |
+| `CHAINLIT_HOST` | No | Override the bind address when not using the default `127.0.0.1`. | Leave empty for Cloud Run; the platform injects the correct host/port. |
+| `CHAINLIT_PORT` | No | Local development port (defaults to `8000`). | Prefer the `$PORT` provided by Cloud Run instead of forcing a value. |
+| `CHAINLIT_URL` | No | Public base URL used in callbacks and invites. | Point to your Cloud Run custom domain or HTTPS Load Balancer endpoint. |
+| `CHAINLIT_ROOT_PATH` | No | Path prefix when the service is behind a reverse proxy. | Set when deploying behind Cloud Run service routes or API Gateway. |
+| `CHAINLIT_DEBUG` | No | Enables verbose logging for troubleshooting. | Disable in production to keep logs tidy and reduce noise in Cloud Logging. |
+| `CHAINLIT_AUTH_SECRET` | Yes (when auth is enabled) | Secret used to sign auth cookies/JWTs. | Store only in Secret Manager and mount as an env var at runtime. |
+| `CHAINLIT_CUSTOM_AUTH` | No | Toggle for custom auth backends. | Keep false unless you have a bespoke auth service hosted on GCP. |
+
+## LLM providers
+
+Populate the values for the providers you actually use. Leave unused providers
+blank to avoid unnecessary secret sprawl.
+
+| Provider | Variables | Notes |
+| --- | --- | --- |
+| OpenAI | `OPENAI_API_KEY` | Mirror to Secret Manager and reference from Cloud Run jobs. |
+| Google Vertex AI | `VERTEX_PROJECT_ID`, `VERTEX_LOCATION` | Use the same project/location as your Vertex endpoint. |
+| Google Gemini | `GEMINI_API_KEY` | Keep in Secret Manager; do not embed in source. |
+| Anthropic | `ANTHROPIC_API_KEY` |  |
+| Azure OpenAI | `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_KEY` | Endpoint should match the regional resource URL. |
+
+## Messaging connectors
+
+| Connector | Variables | Notes |
+| --- | --- | --- |
+| Discord | `DISCORD_BOT_TOKEN` | Restrict secrets using Secret Manager IAM bindings. |
+| Slack | `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_WEBSOCKET_TOKEN` | Required for Socket Mode support. |
+| Microsoft Teams | `TEAMS_APP_ID`, `TEAMS_APP_PASSWORD` | Rotate periodically; store only in Secret Manager. |
+
+## Persistence and storage
+
+| Integration | Variables | Notes |
+| --- | --- | --- |
+| Database | `DATABASE_URL` | Use Cloud SQL with a private connection or connect through Cloud SQL Proxy. |
+| Object storage | `BUCKET_NAME`, `DEV_AWS_ENDPOINT`, `AWS_REGION` | For GCS, leave `DEV_AWS_ENDPOINT` blank and rely on the default endpoint. |
+| Literal AI | `LITERAL_API_KEY`, `LITERAL_API_URL` | Keep API keys centralized in Secret Manager. |
+
+## OAuth providers
+
+Only set the providers you plan to expose. Consider using Secret Manager with
+[Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+when GitHub Actions needs temporary access to these secrets.
+
+| Provider | Variables |
+| --- | --- |
+| GitHub | `OAUTH_GITHUB_CLIENT_ID`, `OAUTH_GITHUB_CLIENT_SECRET` |
+| Google | `OAUTH_GOOGLE_CLIENT_ID`, `OAUTH_GOOGLE_CLIENT_SECRET` |
+| Okta | `OAUTH_OKTA_DOMAIN`, `OAUTH_OKTA_CLIENT_ID`, `OAUTH_OKTA_CLIENT_SECRET` |
+| Auth0 | `OAUTH_AUTH0_DOMAIN`, `OAUTH_AUTH0_CLIENT_ID`, `OAUTH_AUTH0_CLIENT_SECRET` |
+| Amazon Cognito | `OAUTH_COGNITO_DOMAIN`, `OAUTH_COGNITO_CLIENT_ID`, `OAUTH_COGNITO_CLIENT_SECRET` |
+| Generic OAuth | `OAUTH_GENERIC_CLIENT_ID`, `OAUTH_GENERIC_CLIENT_SECRET`, `OAUTH_GENERIC_AUTH_URL`, `OAUTH_GENERIC_TOKEN_URL`, `OAUTH_GENERIC_USER_INFO_URL` |
+
+Add additional provider-specific prompts (for example `OAUTH_PROMPT` or
+`OAUTH_<PROVIDER>_PROMPT`) as needed; keep the entire list in `.env.example` so
+all engineers share the same baseline.
+
+## Secret synchronization workflow
+
+1. Copy `.env.example` to `.env` and populate the variables relevant to your
+   deployment.
+2. Run `python3 scripts/set_gcloud_project.py` to keep the Cloud SDK aligned with
+   the project defined in `.env`. This guarantees local shells, automation, and
+   Cloud Build workers operate against the same project without hand-maintained
+   `gcloud config` calls.
+3. Run `python3 scripts/sync_env_to_gcp.py --create` to upload the populated
+   values to Secret Manager (`CHAINLIT_SECRET_NAME`). When the project ID is not
+   provided via flags or `.env`, the helper falls back to the active `gcloud`
+   configuration established by the previous step.
+4. Reference the secret from Cloud Build triggers or Cloud Run revisions instead
+   of re-declaring the variables manually.
+5. When credentials rotate, update `.env`, rerun the sync script, and redeploy
+   so every environment receives the same update.
+
+This workflow keeps environment configuration DRY and aligns with GCP security
+best practices.
+
+### GCP Secret Manager configuration
+
+Add the following values to `.env` when you want the sync helper to provision
+and manage a Secret Manager secret automatically:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `GCP_PROJECT_ID` | Yes | Project that hosts the Secret Manager secret. |
+| `CHAINLIT_SECRET_NAME` | Yes | Secret resource name populated with key/value pairs from `.env`. |
+| `GCP_SECRET_MANAGER_REPLICA_LOCATION` | No | Secondary region for Secret Manager replicas (for example `us`). Leave blank to use automatic (multi-region) replication. |
+
+To keep CI pipelines DRY, reference the same secret from automation instead of
+redeclaring variables in YAML. When you prefer to configure replication from the
+CLI, pass `--replica-location <region>` to `scripts/sync_env_to_gcp.py`. For
+Cloud Build, add a `secretEnv` section that mounts the secret created by the
+sync helper:
+
+```yaml
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_NUMBER/secrets/${CHAINLIT_SECRET_NAME}/versions/latest
+      env: CHAINLIT_ENV
+steps:
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    secretEnv: ['CHAINLIT_ENV']
+    args:
+      - -c
+      - |
+        printf '%s' "$${CHAINLIT_ENV}" > /workspace/.env.from_secret
+        set -o allexport
+        source /workspace/.env.from_secret
+        set +o allexport
+        pnpm run smoke-test
+```
+
+The example above hydrates the environment from Secret Manager at build time so
+Cloud Build, local shells, and production deployments remain synchronized.
+
+> **Preview without gcloud:** Use `--dry-run` to render the payload without
+> invoking the Secret Manager API or requiring the `gcloud` CLI. This is useful
+> when reviewing diffs locally or on contributors' machines that do not have
+> Cloud SDK installed yet.

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -1,6 +1,9 @@
 # Local Development Smoke Test
 
-This guide documents the minimal steps required to verify that Chainlit starts locally without any custom configuration.
+This guide documents the minimal steps required to verify that Chainlit starts locally without any custom configuration. For a
+complete inventory of supported environment variables, review the
+[environment variable checklist](./environment-variables.md) before wiring
+Chainlit to external services.
 
 ## Prerequisites
 
@@ -77,7 +80,15 @@ We recommend storing any credentials or API keys in a project-level `.env` file 
    finished. The smoke test helper shuts the process down for you.
 
 6. (Optional) Mirror the populated `.env` file to GCP Secret Manager so Cloud
-   Build and other environments reuse the same configuration:
+   Build and other environments reuse the same configuration. Run the project
+   alignment helper first to guarantee the Cloud SDK targets the same project
+   as your `.env`:
+
+   ```bash
+   python3 scripts/set_gcloud_project.py
+   ```
+
+   Then sync the secret payload:
 
    ```bash
    python3 scripts/sync_env_to_gcp.py --create
@@ -85,8 +96,16 @@ We recommend storing any credentials or API keys in a project-level `.env` file 
 
    The helper reads [`.env.example`](../.env.example) to determine which keys
    to upload, skips empty values by default, and provisions the secret when you
-   pass `--create`. Set `GCP_PROJECT_ID` and `CHAINLIT_SECRET_NAME` in `.env`
-   (or export them) to avoid repeating flags.
+   pass `--create`. Populate `GCP_PROJECT_ID`, `CHAINLIT_SECRET_NAME`, and (optionally)
+   `GCP_SECRET_MANAGER_REPLICA_LOCATION` in `.env` so local shells, CI, and Cloud Build all
+   reuse the same configuration without additional flags. If you already export those
+   variables (for example via `direnv`), the script will continue to honor them while
+   falling back to the shared `.env` for DRY defaults and user-managed replication settings
+   required by your data residency policy. When the `.env` and shell are both missing the
+   project ID, the helper now pulls the active `gcloud` configuration instead of failing once
+   [`scripts/set_gcloud_project.py`](../scripts/set_gcloud_project.py) establishes the shared
+   default, and `--dry-run` skips the Cloud SDK requirement entirely so you can preview payloads on fresh
+   machines before installing the CLI.
 
 ## Recommended Next Steps
 
@@ -103,9 +122,10 @@ We recommend storing any credentials or API keys in a project-level `.env` file 
   CI resolve the same dependencies. When those commands fail, reconcile the
   lockfiles (or intentionally fall back) rather than committing ad-hoc
   upgrades.
-- **Bootstrap GCP credentials early**. Run `gcloud auth application-default login` and `gcloud config set project <project-id>` in
-  your local shell (or `.env`) so the hello app can reuse Application Default Credentials when you later connect it to managed
-  services. Keeping these values in `.env` makes it trivial to hydrate the same settings in Secret Manager or Config Connector.
+- **Bootstrap GCP credentials early**. Run `gcloud auth application-default login`, then
+  `python3 scripts/set_gcloud_project.py` so the Cloud SDK always targets the project stored in
+  `.env`. Keeping these values in `.env` makes it trivial to hydrate the same settings in Secret
+  Manager or Config Connector.
 - **Add continuous verification**. Wire the new smoke test into automation. We provide a reusable [GitHub Actions workflow](../.github/workflows/smoke-test.yaml) and a
   [Cloud Build configuration](../cloudbuild/smoke-test.yaml) so merges and nightly jobs exercise the same helper used by
   contributors. This catches lockfile or dependency regressions before they reach production environments.

--- a/scripts/_gcp.py
+++ b/scripts/_gcp.py
@@ -1,0 +1,117 @@
+"""Helpers for interacting with the gcloud CLI and resolving shared config."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+
+from scripts import REPO_ROOT
+
+PROJECT_ENV_CANDIDATES = ("GCP_PROJECT_ID", "VERTEX_PROJECT_ID")
+GCLOUD_CONFIG_PROJECT_KEYS = ("core/project", "core/project_id")
+
+
+def run_gcloud(args: Iterable[str], *, capture_output: bool = False) -> subprocess.CompletedProcess:
+    """Execute a gcloud command while echoing the invocation."""
+
+    command = ["gcloud", *args]
+    print(f"\n→ {' '.join(command)}")
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=capture_output,
+        text=True,
+    )
+
+
+def gcloud_available() -> bool:
+    """Return True when the gcloud CLI is present on PATH."""
+
+    return shutil.which("gcloud") is not None
+
+
+def read_gcloud_project() -> Optional[Tuple[str, str]]:
+    """Return the active gcloud project and the config key it came from."""
+
+    if not gcloud_available():
+        return None
+
+    for key in GCLOUD_CONFIG_PROJECT_KEYS:
+        result = run_gcloud(
+            ["config", "get-value", key, "--quiet"],
+            capture_output=True,
+        )
+        candidate = result.stdout.strip()
+        if result.returncode == 0 and candidate:
+            return candidate, key
+
+    result = run_gcloud(["config", "list", "--format=value(core.project)", "--quiet"], capture_output=True)
+    if result.returncode == 0:
+        candidate = result.stdout.strip()
+        if candidate:
+            return candidate, "config list"
+
+    return None
+
+
+def resolve_setting(
+    cli_value: Optional[str],
+    *,
+    candidate_keys: Iterable[str],
+    env_file_values: Dict[str, str],
+    allow_gcloud_fallback: bool = False,
+) -> Tuple[Optional[str], Optional[Tuple[str, str]]]:
+    """Determine a configuration value and where it originated."""
+
+    if cli_value:
+        return cli_value, None
+
+    for key in candidate_keys:
+        env_value = os.environ.get(key)
+        if env_value:
+            return env_value, ("env", key)
+
+        file_value = env_file_values.get(key, "")
+        if file_value:
+            return file_value, ("file", key)
+
+    if allow_gcloud_fallback:
+        gcloud_project = read_gcloud_project()
+        if gcloud_project:
+            project, config_key = gcloud_project
+            return project, ("gcloud", config_key)
+
+    return None, None
+
+
+def log_source(name: str, source: Optional[Tuple[str, str]], source_path: Path) -> None:
+    """Print where a resolved value originated for auditability."""
+
+    if not source:
+        return
+
+    origin, key = source
+    if origin == "env":
+        print(f"Using {name} from environment variable {key}.")
+    elif origin == "file":
+        try:
+            relative = source_path.relative_to(REPO_ROOT)
+        except ValueError:
+            relative = source_path
+        print(f"Using {name} from {relative} entry {key}.")
+    elif origin == "gcloud":
+        print(f"Using {name} from gcloud config value {key}.")
+
+
+__all__ = [
+    "PROJECT_ENV_CANDIDATES",
+    "GCLOUD_CONFIG_PROJECT_KEYS",
+    "gcloud_available",
+    "log_source",
+    "read_gcloud_project",
+    "resolve_setting",
+    "run_gcloud",
+]

--- a/scripts/set_gcloud_project.py
+++ b/scripts/set_gcloud_project.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Ensure the gcloud CLI uses the project configured in the shared .env."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict
+
+if __package__ is None:  # pragma: no cover - executed when run as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import REPO_ROOT
+from scripts._env import ENV_FILE, parse_env_file
+from scripts._gcp import (
+    PROJECT_ENV_CANDIDATES,
+    gcloud_available,
+    log_source,
+    read_gcloud_project,
+    resolve_setting,
+    run_gcloud,
+)
+
+
+def _load_env(source: Path) -> Dict[str, str]:
+    """Read key/value pairs from the provided env file."""
+
+    if not source.exists():
+        return {}
+    return parse_env_file(source)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Align the local gcloud config with the project specified in the shared .env so "
+            "Secret Manager syncs and other helpers stay DRY across shells."
+        )
+    )
+    parser.add_argument(
+        "--project",
+        default=None,
+        help=(
+            "Optional project ID. When omitted the script falls back to environment variables "
+            f"{', '.join(PROJECT_ENV_CANDIDATES)} or their entries in .env."
+        ),
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=ENV_FILE,
+        help="Path to the .env file to read (defaults to the repository .env).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the gcloud command without executing it.",
+    )
+    args = parser.parse_args()
+
+    source_path = args.source if args.source.is_absolute() else REPO_ROOT / args.source
+    env_values = _load_env(source_path)
+
+    project, project_source = resolve_setting(
+        args.project,
+        candidate_keys=PROJECT_ENV_CANDIDATES,
+        env_file_values=env_values,
+    )
+    if not project:
+        existing = read_gcloud_project()
+        if existing:
+            current_project, key = existing
+            raise SystemExit(
+                "Populate .env with GCP_PROJECT_ID (or VERTEX_PROJECT_ID) or pass --project so the CLI matches the shared "
+                f"configuration. gcloud currently targets '{current_project}' via {key}."
+            )
+        raise SystemExit(
+            "Populate .env with GCP_PROJECT_ID (or VERTEX_PROJECT_ID) or pass --project so the CLI matches the shared configuration."
+        )
+
+    log_source("project", project_source, source_path)
+
+    if args.dry_run:
+        print("\nDry run – would execute:\n")
+        print(f"gcloud config set project {project} --quiet")
+        return
+
+    if not gcloud_available():
+        raise SystemExit("gcloud CLI is required. Install it and authenticate before setting the project.")
+
+    result = run_gcloud(["config", "set", "project", project, "--quiet"])
+    if result.returncode != 0:
+        raise SystemExit("Failed to set the gcloud project. Review the output above for details.")
+
+    print(
+        f"\nConfigured gcloud to use project '{project}'. Future Secret Manager syncs and build steps will now reuse the same "
+        "project ID defined in .env."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_env_to_gcp.py
+++ b/scripts/sync_env_to_gcp.py
@@ -4,9 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import os
-import shutil
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -17,9 +14,17 @@ if __package__ is None:  # pragma: no cover - executed when run as a script
 
 from scripts import REPO_ROOT
 from scripts._env import ENV_FILE, ENV_TEMPLATE, parse_env_file
+from scripts._gcp import (
+    PROJECT_ENV_CANDIDATES,
+    gcloud_available,
+    log_source,
+    resolve_setting,
+    run_gcloud,
+)
 
 DEFAULT_PROJECT_ENV = "GCP_PROJECT_ID"
 DEFAULT_SECRET_ENV = "CHAINLIT_SECRET_NAME"
+DEFAULT_REPLICA_ENV = "GCP_SECRET_MANAGER_REPLICA_LOCATION"
 
 
 def _build_payload(
@@ -43,21 +48,8 @@ def _build_payload(
             payload.append(f"{key}={value}")
 
     return payload
-
-
-def _run_gcloud(args: Iterable[str], *, capture_output: bool = False) -> subprocess.CompletedProcess:
-    command = ["gcloud", *args]
-    print(f"\n→ {' '.join(command)}")
-    return subprocess.run(
-        command,
-        check=False,
-        capture_output=capture_output,
-        text=True,
-    )
-
-
 def _secret_exists(project: str, secret: str) -> bool:
-    result = _run_gcloud(
+    result = run_gcloud(
         [
             "secrets",
             "describe",
@@ -72,23 +64,26 @@ def _secret_exists(project: str, secret: str) -> bool:
     return result.returncode == 0
 
 
-def _create_secret(project: str, secret: str) -> None:
-    result = _run_gcloud(
-        [
-            "secrets",
-            "create",
-            secret,
-            "--project",
-            project,
-            "--replication-policy=automatic",
-        ]
-    )
+def _create_secret(project: str, secret: str, replica_location: str | None) -> None:
+    command = [
+        "secrets",
+        "create",
+        secret,
+        "--project",
+        project,
+    ]
+    if replica_location:
+        command.extend(["--replication-policy=user-managed", f"--locations={replica_location}"])
+    else:
+        command.append("--replication-policy=automatic")
+
+    result = run_gcloud(command)
     if result.returncode != 0:
         raise SystemExit(f"Failed to create secret '{secret}' in project '{project}'.")
 
 
 def _add_secret_version(project: str, secret: str, data_path: Path) -> None:
-    result = _run_gcloud(
+    result = run_gcloud(
         [
             "secrets",
             "versions",
@@ -126,6 +121,14 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--replica-location",
+        default=None,
+        help=(
+            "Optional Secret Manager replica location (for example 'us'). "
+            f"Defaults to the environment variable {DEFAULT_REPLICA_ENV}. When omitted the secret uses automatic replication."
+        ),
+    )
+    parser.add_argument(
         "--source",
         type=Path,
         default=ENV_FILE,
@@ -148,25 +151,6 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if shutil.which("gcloud") is None:
-        raise SystemExit("gcloud CLI is required. Install it and authenticate before syncing secrets.")
-
-    project = (
-        args.project
-        or os.environ.get(DEFAULT_PROJECT_ENV)
-        or os.environ.get("VERTEX_PROJECT_ID")
-    )
-    if not project:
-        raise SystemExit(
-            "Set --project, GCP_PROJECT_ID, or VERTEX_PROJECT_ID so the script knows which project to target."
-        )
-
-    secret = args.secret or os.environ.get(DEFAULT_SECRET_ENV)
-    if not secret:
-        raise SystemExit(
-            "Set --secret or the CHAINLIT_SECRET_NAME environment variable to identify the Secret Manager entry."
-        )
-
     if not ENV_TEMPLATE.exists():
         raise SystemExit("Missing .env.example. Populate it before mirroring secrets to GCP.")
 
@@ -181,6 +165,36 @@ def main() -> None:
     env_values = parse_env_file(source_path)
     if not env_values:
         raise SystemExit(f"No key/value pairs found in {source_path}. Populate it before syncing to GCP.")
+
+    project, project_source = resolve_setting(
+        args.project,
+        candidate_keys=PROJECT_ENV_CANDIDATES,
+        env_file_values=env_values,
+        allow_gcloud_fallback=not args.dry_run,
+    )
+    if not project:
+        raise SystemExit(
+            "Set --project, GCP_PROJECT_ID, or VERTEX_PROJECT_ID (for Vertex AI workloads) so the script knows which project to target."
+        )
+    log_source("project", project_source, source_path)
+
+    secret, secret_source = resolve_setting(
+        args.secret,
+        candidate_keys=(DEFAULT_SECRET_ENV,),
+        env_file_values=env_values,
+    )
+    if not secret:
+        raise SystemExit(
+            "Set --secret, CHAINLIT_SECRET_NAME, or define the key in your .env so the script can identify the Secret Manager entry."
+        )
+    log_source("secret", secret_source, source_path)
+
+    replica_location, replica_source = resolve_setting(
+        args.replica_location,
+        candidate_keys=(DEFAULT_REPLICA_ENV,),
+        env_file_values=env_values,
+    )
+    log_source("replica location", replica_source, source_path)
 
     missing_required = [key for key in template_values if not env_values.get(key)]
     if missing_required and not args.include_empty:
@@ -200,12 +214,15 @@ def main() -> None:
         print("\n".join(payload_lines))
         return
 
+    if not gcloud_available():
+        raise SystemExit("gcloud CLI is required. Install it and authenticate before syncing secrets.")
+
     if not _secret_exists(project, secret):
         if not args.create:
             raise SystemExit(
                 f"Secret '{secret}' does not exist in project '{project}'. Pass --create to provision it automatically."
             )
-        _create_secret(project, secret)
+        _create_secret(project, secret, replica_location)
 
     with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
         tmp.write("\n".join(payload_lines) + "\n")


### PR DESCRIPTION
## Summary
- add a shared `scripts/_gcp.py` helper that resolves env-backed project IDs, wraps gcloud execution, and logs value provenance
- introduce `scripts/set_gcloud_project.py` so developers and CI can sync the Cloud SDK project with the shared `.env` before running Secret Manager workflows
- update `scripts/sync_env_to_gcp.py`, `.env.example`, and the onboarding docs to reference the new helper and keep gcloud configuration DRY

## Testing
- python3 -m compileall scripts
- pnpm run lintPython *(fails offline while fetching mypy; rerun once dependencies are cached)*

------
https://chatgpt.com/codex/tasks/task_e_68e597d9b81c8330b770924716756fce